### PR TITLE
Fix simulator to work with latest grbl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ add_compile_definitions(F_CPU=16000000)
 
 set(grbl_SRC 
     src/grbl/grbllib.h
+    src/grbl/crossbar.c
     src/grbl/grbllib.c
     src/grbl/protocol.h
     src/grbl/protocol.c
@@ -18,6 +19,7 @@ set(grbl_SRC
     src/grbl/stepper.c
     src/grbl/gcode.h
     src/grbl/gcode.c
+    src/grbl/messages.c
     src/grbl/stream.h
     src/grbl/stream.c
     src/grbl/spindle_control.h
@@ -77,10 +79,16 @@ if(UNIX)
         src/platform_linux.c
     )
 
-    set(platform_LIB
-        rt
-        pthread
-    )
+    if(APPLE)
+        set(platform_LIB
+            pthread
+        )
+    else(APPLE)
+        set(platform_LIB
+            rt
+            pthread
+        )
+    endif(APPLE)
 endif(UNIX)
 
 add_executable(grblHAL_sim 

--- a/src/planner_inject_accessors.c
+++ b/src/planner_inject_accessors.c
@@ -1,5 +1,7 @@
 #include "grbl/hal.h"
 
+#define BLOCK_BUFFER_SIZE 256
+
 static plan_block_t block_buffer[BLOCK_BUFFER_SIZE];  // A ring buffer for motion instructions
 plan_block_t *get_block_buffer() { return block_buffer; }
 

--- a/src/validator.c
+++ b/src/validator.c
@@ -46,6 +46,7 @@ arg_vars_t args;
 const char* progname;
 uint8_t exit_code = 0;
 
+
 int usage (const char* badarg)
 {
     if (badarg)
@@ -66,7 +67,7 @@ int usage (const char* badarg)
 
 status_code_t validator_report_status_message (status_code_t status_code)
 {
-    report_status_message(status_code);
+    //report_status_message(status_code);
 
     if (status_code && !exit_code) {
         printf("EXITING %d\n",status_code);
@@ -189,8 +190,8 @@ int main(int argc, char *argv[])
     settings_init();
 
     report_init_fns();
-    grbl.report.status_message = validator_report_status_message;
-    grbl.report.feedback_message = report_feedback_message;
+    //grbl.report.status_message = validator_report_status_message;
+    //grbl.report.feedback_message = report_feedback_message;
 
     hal.stream.read = serial_read;
     hal.stream.write = serial_write;

--- a/src/validator_driver.c
+++ b/src/validator_driver.c
@@ -201,13 +201,13 @@ bool driver_init ()
     hal.probe.get_state = probeGetState;
     hal.probe.configure = probeConfigureInvertMask;
 
-    hal.spindle.set_state = spindleSetState;
-    hal.spindle.get_state = spindleGetState;
+    //hal.spindle.set_state = spindleSetState;
+    //hal.spindle.get_state = spindleGetState;
 #ifdef SPINDLE_PWM_DIRECT
-    hal.spindle.get_pwm = spindleGetPWM;
-    hal.spindle.update_pwm = spindle_set_speed;
+    //hal.spindle.get_pwm = spindleGetPWM;
+    //hal.spindle.update_pwm = spindle_set_speed;
 #else
-    hal.spindle.update_rpm = spindleUpdateRPM;
+    //hal.spindle.update_rpm = spindleUpdateRPM;
 #endif
 
     hal.control.get_state = systemGetState;
@@ -224,7 +224,7 @@ bool driver_init ()
 
     hal.driver_cap.amass_level = 3;
 
-    hal.driver_cap.spindle_pwm_linearization = On;
+    //hal.driver_cap.spindle_pwm_linearization = On;
     hal.driver_cap.mist_control = On;
 
     hal.driver_cap.control_pull_up = On;


### PR DESCRIPTION
- Fixed CMakeLists to have missing files.
- Fixed build to work on apple (by not including rt)
- Fixed to new update interface in HAL (takes mask now)
- Register a spindle so driver check succeeds.
- Update driver version
- Remove pwm linearization option setting which seems not to exist.
- Update hal signature for limit switches in hal