### PR TITLE
Fix compilation against latest grbl

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -134,7 +134,6 @@ const io_stream_t *serialInit (void)
 {
         static const io_stream_t stream = {
         .type = StreamType_Serial,
-        .state.connected = true,
         .read = serialGetC,
         .write = serialWriteS,
         .write_char = serialPutC,


### PR DESCRIPTION
With commit https://github.com/grblHAL/core/commit/81fe93adb80fdd943154f8146abfe3ce84352ebb the flag `connected` got removed from `io_stream_state_t`. A replacement with a static "retrun true" function for `io_stream_t.is_connected` does not seem to be necessary.