### PR TITLE
Ensure truncation in `platform_ns` in case of overflow and avoid "undefined behaviour"

### DIFF
--- a/src/platform_linux.c
+++ b/src/platform_linux.c
@@ -48,7 +48,7 @@ uint32_t platform_ns()
     struct timespec ts;
 
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    timestamp = ts.tv_sec * 1e9 + ts.tv_nsec;
+    timestamp = ts.tv_sec * (uint32_t)1e9 + ts.tv_nsec;
     if (gTimeBase == 0)
         gTimeBase = timestamp;
 


### PR DESCRIPTION
The previous code did a conversion to double, due to the multiplication with the double constant `1e9`, and finally assigned to an unsigned int. In case of an overflow, i.e. when the double is larger than the target int, the behaviour is undefined as per C standard.
In case of LVVM (Apple clang version 16.0.0 (clang-1600.0.26.4), targeting arm64-apple-darwin23.6.0) it looks like implementors choose to return a saturated value -- I always see `4294967295`, which is `0xf...f` aka `(1<<32) - 1`. This happens if the `tv_sec` part returned by `clock_gettime` is "large"; in my case ca. 1.4e6 after an uptime of 16 days. This again results in `platfrom_ns` always returning zero, thus the simulator gets stuck.

This commit prevents the conversion to double by multiplying with an unsigned integer constant instead. For integers, the overflow-behaviour is defined as truncation, which is exactly what `platform_ns` is supposed to do, as per docstring. Indeed, the simulator now works on macOS.