### PR TITLE
Improve Time Factor Handling

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -418,7 +418,7 @@ bool driver_setup (settings_t *settings)
 // ensures hardware simulator gets some cycles in "parallel"
 void sim_process_realtime (uint_fast16_t state)
 {
-    platform_sleep(0);
+    //platform_sleep(0); // yield needed? or simply trust the OS's thread scheduler...
     on_execute_realtime(state);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@ int usage(const char* badarg)
       "%s [options] [time_step] [block_file]\n"
       "  Options:\n"
       "    -r <report time>   : minimum time step for printing stepper values. Default=0=no print.\n"
-      "    -t <time factor>   : multiplier to realtime clock. Default=1. (needs work)\n"
+      "    -t <time factor>   : multiplier to realtime clock. Default=1.0; 0=\"as fast as possible\"\n"
       "    -g <response file> : file to report responses from grbl.  default = stdout\n"
       "    -b <block file>    : file to report each block executed.  default = stdout\n"
       "    -s <step file>     : file to report each step executed.  default = stderr\n"
@@ -176,7 +176,6 @@ static void exithandler (int signum)
 
 int main(int argc, char *argv[])
 {
-    float tick_rate = 1.0f;
     int positional_args = 0;
 
     //defaults
@@ -184,6 +183,7 @@ int main(int argc, char *argv[])
     args.block_out_file = stdout;
     args.serial_out_file = stdout;
     args.comment_char = '#';
+    args.speedup = 1.0f;
 
     args.step_time = 0.0f;
     // Get the minimum time step for printing stepper values.
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
 
                 case 't': //Tick rate
                     argv++; argc--;
-                    tick_rate = atof(*argv);
+                    args.speedup = atof(*argv);
                     break;
 
                 case 'b': //Block file
@@ -304,7 +304,7 @@ int main(int argc, char *argv[])
     sim.on_tick = grbl_per_tick;
     sim.on_byte = grbl_per_byte;
 
-    init_simulator(tick_rate);
+    init_simulator();
 
     if(args.port) {
 

--- a/src/simulator.h
+++ b/src/simulator.h
@@ -33,10 +33,10 @@ typedef void (*sim_hook_fp)(void); // Signature of functions to be inserted in s
 //simulation globals
 typedef struct sim_vars {
     uint64_t masterclock;
-    double sim_time;  // current time of the simulation.
+    double sim_time;  // current time of the simulation, in seconds since start.
     uint8_t started;  // don't start timers until first char recieved.
     enum {exit_NO, exit_REQ, exit_OK} exit;
-    float speedup;
+    float speedup; // current factor how much faster/slower sim time is compared to real time
     int32_t baud_ticks;
 #ifdef WIN32
     SOCKET socket_fd;
@@ -58,7 +58,8 @@ typedef struct arg_vars {
     FILE *block_out_file;
     FILE *step_out_file;
     FILE *serial_out_file;
-    double step_time;       // Minimum time step for printing stepper values. Given by user via command line
+    float speedup;          // desired factor how much faster/slower sim time is compared to real time. 0 means "a fast at possible"
+    double step_time;       // Minimum time step for printing stepper values, in sim time. Given by user via command line
     uint8_t comment_char;   // Char to prefix comments; default  '#' 
     uint16_t port;          // Port number for telnet communication
 } arg_vars_t;
@@ -69,7 +70,7 @@ extern arg_vars_t args;
 //extern system_t sys;
 
 // setup avr simulation
-void init_simulator (float time_multiplier);
+void init_simulator (void);
 
 // Shutdown simulator - run shutdown hooks, save eeeprom
 void shutdown_simulator (void);


### PR DESCRIPTION
As before, there are two modes: "(scaled) realtime approximation" and "as fast as possible". The main change now is to introduce a feedback loop that adjusts the sleep time and the scheduled number of simulated MCU clock ticks per "control frame", while trying to keep the duration of this control frame constant. This fixes two issues:
 - The previous code suffered from the "spiral of death", where each frame got longer and longer if the host was too slow: to catch up, even more ticks got scheduled, taking even more time to complete.
 - There was a very small and fixed amount of sleep, even in "fast mode", that according to the original comment should yield the control back to the OS to allow the other threads to get scheduled. With a modern preemptive OS this should not be necessary -- we now simply trust the OS' scheduler. This massively reduces the time spend in kernel-mode and is in fact a precondition for the "fast mode" to be fast: Previously there has been one sleep, and thus one potential context switch, per simulated tick, resulting in "fast mode" being utterly slow.

Then, the `speedup` in the simulator state structure is now the current speedup, calculated over the last control frame. The desired target value given by the user via CLI flag, is moved to the `args` structure. The current speedup is now available in both modes, i.e. it's also for the "fast mode".

I did this work on macOS and testes using such a bash snippet:
``` sh
# to quit gracefully, we need to send an ACK (^F, or \x06)
time echo -e "g0x10\ny10\nx0y0\n\x06" | ./build/grblHAL_sim -r 0.1 -t 0
```
on a 3.5 GHz M2 (arm64) I can simulate the MCU with it's default 16 MHz clock rate up to ca. `-t 1.5` -- above that behaves just like `-t 0`, i.e. "fast as possible". Previously, `-t 0` was not usable at all and larger speedups (i.e. `-t 5`) resulted in a huge lag after sending Ctrl-F. Sys time went down from over 3s to under 0.3s.