### PR TITLE
Fix serial speed

### DIFF
--- a/src/simulator.c
+++ b/src/simulator.c
@@ -110,7 +110,9 @@ void sim_loop (void)
             sim.on_tick();
 
             if (read_serial) {
-                next_byte_tick += sim.baud_ticks;
+                // baud rate is for symbols and UART has 1 bit per symbol.
+                // with a typical 8N1 serial, we need 10 symbols per byte
+                next_byte_tick += sim.baud_ticks * 10;
                 // do app-specific per-byte processing
                 sim.on_byte();
             }


### PR DESCRIPTION
Previously, a byte from the serial was read every `baud_ticks`, with this holding the simulated MCU clock ticks divided by the serial baud rate. However, the baud rate is the symbol rate, not the byte rate. UART has 1 bit per symbol and requires 10 bits per byte in a typical 8N1 configuration. Thus we're only allowed to read a byte from the serial every ten baud ticks.

One question here: Why do we [wait one (simulated) Second](https://github.com/grblHAL/Simulator/blob/9b73baa86c1a3e1dca38da5219e912d354f2c79c/src/simulator.c#L88) before reading the serial for the first time? This seems rather long; is there maybe another way to determine when the MCU has finished setup the serial?