### PR TITLE
Setup Github Actions for Build and Test

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,60 @@
+name: CMake/Build/Test on multiple platforms
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations.
+      # Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        c_compiler: [gcc, clang]
+        exclude:
+        - os: windows-latest
+          c_compiler: clang
+        - os: macos-latest
+          c_compiler: gcc
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs.
+      # These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake Generator for Windows
+      if: runner.os == 'Windows'
+      run: |
+        echo CMAKE_GENERATOR="MinGW Makefiles" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: CMake
+      run: >
+        cmake
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -B ${{ steps.strings.outputs.build-output-dir }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }}
+
+    - name: Smoke Test
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      shell: bash
+      run: |
+        ./grblHAL_validator -h
+        ./grblHAL_sim -h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ if (WIN32)
         src/platform_windows.c
     )
 
-    set(platform_LIB)
+    set(platform_LIB
+        ws2_32
+    )
 endif(WIN32)
 
 if(UNIX)

--- a/src/main.c
+++ b/src/main.c
@@ -53,7 +53,7 @@ static int socket_fd = 0;
 #endif
 static fd_set rfds;
 
-int usage(const char* badarg)
+void print_usage(const char* badarg)
 {
     if (badarg)
         printf("Unrecognized option %s\n",badarg);
@@ -71,11 +71,12 @@ int usage(const char* badarg)
       "    -c<comment_char>   : character to print before each line from grbl.  default = '#'\n"
       "    -n                 : no comments before grbl response lines.\n"
       "    -h                 : this help.\n"
-      "\n  <time_step> and <block_file> can be specifed with option flags or positional parameters\n"
-      "\n  ^-F to shutdown cleanly\n\n",
+      "\n"
+      "  <time_step> and <block_file> can be specifed with option flags or positional parameters\n"
+      "\n"
+      "  ^-F to shutdown cleanly\n"
+      "\n",
       progname);
-
-    return -1;
 }
 
 //wrapper for thread interface
@@ -219,7 +220,7 @@ int main(int argc, char *argv[])
                     if (!args.block_out_file) {
                         perror("fopen");
                         printf("Error opening : %s\n",*argv);
-                        return(usage(0));
+                        return EXIT_FAILURE;
                     }
                     break;
 
@@ -234,7 +235,7 @@ int main(int argc, char *argv[])
                     if (!args.step_out_file) {
                         perror("fopen");
                         printf("Error opening : %s\n",*argv);
-                        return(usage(0));
+                        return EXIT_FAILURE;
                     }
                     break;
 
@@ -244,7 +245,7 @@ int main(int argc, char *argv[])
                     if (!args.serial_out_file) {
                         perror("fopen");
                         printf("Error opening : %s\n",*argv);
-                        return(usage(0));
+                        return EXIT_FAILURE;
                     }
                     break;
 
@@ -259,10 +260,12 @@ int main(int argc, char *argv[])
                     break;
 
                 case 'h':
-                    return usage(NULL);
+                    print_usage(NULL);
+                    return EXIT_SUCCESS;
 
                 default:
-                    return usage(*argv);
+                    print_usage(*argv);
+                    return EXIT_FAILURE;
             }
         }
         else { //handle old positional argument interface
@@ -278,13 +281,14 @@ int main(int argc, char *argv[])
                     if (!args.block_out_file) {
                         perror("fopen");
                         printf("Error opening : %s\n",*argv);
-                        return(usage(0));
+                        return EXIT_FAILURE;
                     }
                     args.serial_out_file = args.block_out_file;
                     break;
 
                 default:
-                    return usage(*argv);
+                    print_usage(*argv);
+                    return EXIT_FAILURE;
             }
         }
     }

--- a/src/validator.c
+++ b/src/validator.c
@@ -49,7 +49,7 @@ arg_vars_t args;
 const char* progname;
 uint8_t exit_code = 0;
 
-int usage (const char* badarg)
+void print_usage (const char* badarg)
 {
     if (badarg)
         printf("Unrecognized option %s\n", badarg);
@@ -60,11 +60,12 @@ int usage (const char* badarg)
      "    -o <output file> : use output file instead of stdout\n"
      "    -e        : echo input to output\n"
      "    -s        : silent, no output only return code \n"
-     "\n  Parses gcode from stdin or input line, prints grbl's expected response"
-     "\n  Returns 0 on successs, or line number of error",
+     "\n"
+     "  Parses gcode from stdin or input line, prints grbl's expected response.\n"
+     "\n"
+     "  Returns 0 on successs, or line number of error.\n"
+     "\n",
      progname);
-
-    return -1;
 }
 
 status_code_t validator_report_status_message (status_code_t status_code)
@@ -142,14 +143,17 @@ int main(int argc, char *argv[])
                     if (!args.output_file) {
                         perror("fopen");
                         printf("Error opening : %s\n",*argv);
-                        return(usage(0));
+                        return EXIT_FAILURE;
                     }
                     break;
 
                 case 'h':
-                    return usage(NULL);
+                    print_usage(NULL);
+                    return EXIT_SUCCESS;
+
                 default:
-                    return usage(*argv);
+                    print_usage(*argv);
+                    return EXIT_FAILURE;
             }
         } else { //handle positional arguments
             positional_args++;
@@ -160,12 +164,13 @@ int main(int argc, char *argv[])
                     if (!args.input_file) {
                         perror("fopen");
                         printf("Error opening : %s\n",*argv);
-                        return(usage(0));
+                        return EXIT_FAILURE;
                     }
                     break;
 
                 default:
-                    return usage(*argv);
+                    print_usage(*argv);
+                    return EXIT_FAILURE;
             }
         }
     }


### PR DESCRIPTION
Based on the [cmake-multi-platform template](https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml) a first CI pipeline is set up, that builds on Windows, Linux and macOS, using gcc and clang. As rudimentary smoke tests the resulting executables are started with `-h`.

To use this "help" as smoke test, I changed the exit code to zero when the help is displayed on explicit user request. It's still non-zero in case of CLI argument errors. This change is encapsulated in an independent commit.

Windows required a bit of extra work as the default compiler, Microsoft's cl.exe cannot compile grbl, so gcc from MinGW64 is used. But this one does not work with the default CMake generator on Windows, which is MSBuild.
I also figured out that a required lib was not linked in the Windows build; This issue in the CMakeLists.txt is fixed in a dedicated commit.